### PR TITLE
Limit repo commenting, point issue comment at correct repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@ version = "0.1.0"
 dependencies = [
  "github_v3 0.1.0 (git+https://github.com/acmcarther/github_v3_rust?rev=abf6e3b)",
  "iron 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -120,6 +121,11 @@ dependencies = [
  "typemap 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 0.2.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itertools"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "catalyst"
 version = "0.1.0"
 dependencies = [
- "github_v3 0.1.0 (git+https://github.com/acmcarther/github_v3_rust?rev=abf6e3b)",
+ "github_v3 0.1.0 (git+https://github.com/acmcarther/github_v3_rust?rev=f387bbd)",
  "iron 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.3.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "router 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -64,7 +64,7 @@ dependencies = [
 [[package]]
 name = "github_v3"
 version = "0.1.0"
-source = "git+https://github.com/acmcarther/github_v3_rust?rev=abf6e3b#abf6e3b5872c233f027e687e86a5cea133c9e8b5"
+source = "git+https://github.com/acmcarther/github_v3_rust?rev=f387bbd#f387bbd4915f34efcb1500d589ecf027b2d17495"
 dependencies = [
  "hyper 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ time = "*"
 rustc-serialize = "0.3.16"
 iron = "*"
 router = "*"
+itertools = "*"
 
 
 [dependencies.github_v3]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ itertools = "*"
 
 [dependencies.github_v3]
 git = "https://github.com/acmcarther/github_v3_rust"
-rev = "abf6e3b"
+rev = "f387bbd"

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+/assets/bundle.js

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,13 @@
+<!-- index.html -->
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Hello React</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/0.13.3/react.js"></script>
+  </head>
+  <body>
+    <div id="content"></div>
+    <script src="assets/bundle.js"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "catalyst-client",
+  "version": "0.0.1",
+  "description": "",
+  "main": "index.js",
+  "dependencies": {
+    "react": "^0.13.3",
+    "react-bootstrap": "^0.24.3",
+    "react-router": "^0.13.3"
+  },
+  "devDependencies": {
+    "coffee-loader": "^0.7.2",
+    "coffee-script": "^1.9.3",
+    "css-loader": "^0.15.6",
+    "exports-loader": "^0.6.2",
+    "expose-loader": "^0.7.0",
+    "imports-loader": "^0.6.4",
+    "jsx-loader": "^0.13.2",
+    "cjsx-loader": "^2.0.1",
+    "load-grunt-tasks": "^3.2.0",
+    "node-sass": "^3.2.0",
+    "react-hot-loader": "^1.2.8",
+    "sass-loader": "^1.0.4",
+    "style-loader": "^0.12.3",
+    "webpack": "^1.10.5",
+    "webpack-dev-server": "^1.10.1"
+  }
+}

--- a/client/src/index.coffee
+++ b/client/src/index.coffee
@@ -1,0 +1,3 @@
+Main = require './main.coffee'
+
+React.render (Main {}) , document.body

--- a/client/src/main.coffee
+++ b/client/src/main.coffee
@@ -1,0 +1,13 @@
+Timer = require './timer.coffee'
+
+{div, h1, h2} = React.DOM
+
+Main = React.createClass
+  render: ->
+    div {},
+      h1 {}, 'Catalyst'
+      h2 {}, 'A github build management bot'
+      div {}, Timer {}
+
+module.exports = React.createFactory Main
+

--- a/client/src/timer.coffee
+++ b/client/src/timer.coffee
@@ -1,0 +1,20 @@
+{ div } = React.DOM
+
+Timer = React.createClass
+  getInitialState: ->
+    return {secondsElapsed: 0};
+
+  tick: ->
+    @setState({secondsElapsed: @state.secondsElapsed + 1});
+
+  componentDidMount: ->
+    @interval = setInterval(@tick, 1000);
+
+  componentWillUnmount: ->
+    clearInterval(@interval);
+
+  render: ->
+    div {}, "Seconds Elapsed: #{@state.secondsElapsed}"
+
+module.exports = React.createFactory Timer
+

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,0 +1,30 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+  entry: [
+    './src/index.coffee'
+  ],
+  devtool: "eval",
+  debug: true,
+  output: {
+    path: path.join(__dirname, "assets"),
+    filename: 'bundle.js'
+  },
+  resolveLoader: {
+    modulesDirectories: ['node_modules']
+  },
+  plugins: [
+    new webpack.NoErrorsPlugin(),
+    new webpack.IgnorePlugin(/vertx/) // https://github.com/webpack/webpack/issues/353
+  ],
+  resolve: {
+    extensions: ['', '.js', '.coffee']
+  },
+  module: {
+    loaders: [
+      { test: /\.css$/, loaders: ['style', 'css']},
+      { test: /\.coffee$/, loader: 'coffee' }
+    ]
+  }
+}

--- a/src/listening.rs
+++ b/src/listening.rs
@@ -1,179 +1,171 @@
-pub use self::listening::{
-  spawn_listener
+use iron::status;
+use iron::prelude::*;
+use iron::error::HttpError;
+use iron::headers::{parsing, Header, HeaderFormat};
+use iron::{BeforeMiddleware, AfterMiddleware, typemap};
+
+use router::Router;
+
+use std::fmt;
+use std::io::Read;
+use std::sync::Mutex;
+use std::ascii::AsciiExt;
+use std::sync::mpsc::Sender;
+
+use github_v3::types::comments::{
+  IssueCommentEvent,
+  PullRequestReviewCommentEvent,
 };
+use github_v3::types::PushEvent;
+use github_v3::types::pull_requests::PullRequestEvent;
 
-mod listening {
-  use iron::prelude::*;
-  use iron::status;
-  use router::Router;
-  use iron::headers::{parsing, Header, HeaderFormat};
-  use iron::error::HttpError;
+use rustc_serialize::{json};
 
-  use std::io::Read;
+fn handle_root(_: &mut Request) -> IronResult<Response> {
+  Ok(Response::with((status::Ok, "Hello from Catalyst. At some point a configuration page will live here.")))
+}
 
-  use std::fmt;
-  use std::ascii::AsciiExt;
-  use std::sync::Mutex;
+#[derive(Clone, PartialEq, Debug)]
+pub struct GithubEventHeader {
+  pub event_name: String
+}
 
-  use github_v3::types::comments::{
-    IssueCommentEvent,
-    PullRequestReviewCommentEvent,
-  };
-  use github_v3::types::pull_requests::PullRequestEvent;
-  use github_v3::types::PushEvent;
-
-  use rustc_serialize::{json};
-  use std::sync::mpsc::Sender;
-
-  use iron::{BeforeMiddleware, AfterMiddleware, typemap};
-
-
-  fn handle_root(_: &mut Request) -> IronResult<Response> {
-    Ok(Response::with((status::Ok, "Hello from Catalyst. At some point a configuration page will live here.")))
+impl Header for GithubEventHeader {
+  fn header_name() -> &'static str {
+      "X-Github-Event"
   }
-
-  #[derive(Clone, PartialEq, Debug)]
-  pub struct GithubEventHeader {
-    pub event_name: String
+  fn parse_header(raw: &[Vec<u8>]) -> Result<GithubEventHeader, HttpError> {
+    parsing::from_one_raw_str(raw).and_then(|s: String| {
+      Ok(GithubEventHeader{event_name: s.to_ascii_lowercase()})
+    })
   }
+}
 
-  impl Header for GithubEventHeader {
-    fn header_name() -> &'static str {
-        "X-Github-Event"
-    }
-    fn parse_header(raw: &[Vec<u8>]) -> Result<GithubEventHeader, HttpError> {
-      parsing::from_one_raw_str(raw).and_then(|s: String| {
-        Ok(GithubEventHeader{event_name: s.to_ascii_lowercase()})
-      })
-    }
+impl HeaderFormat for GithubEventHeader {
+  fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    f.write_str(&self.event_name)
   }
+}
 
-  impl HeaderFormat for GithubEventHeader {
-    fn fmt_header(&self, f: &mut fmt::Formatter) -> fmt::Result {
-      f.write_str(&self.event_name)
-    }
-  }
+enum EventType {
+  IssueComment,
+  PullRequestReviewComment,
+  PullRequest,
+  Push,
+  UnknownEvent,
+}
 
-  enum EventType {
-    IssueComment,
-    PullRequestReviewComment,
-    PullRequest,
-    Push,
-    UnknownEvent,
-  }
+struct Deserialize;
 
-  struct Deserialize;
+struct EventInfo;
+impl typemap::Key for EventInfo { type Value = EventType; }
 
-  struct EventInfo;
-  impl typemap::Key for EventInfo { type Value = EventType; }
+struct IsIssueComment;
+impl typemap::Key for IsIssueComment { type Value = IssueCommentEvent; }
 
-  struct IsIssueComment;
-  impl typemap::Key for IsIssueComment { type Value = IssueCommentEvent; }
+struct IsPullRequestReviewComment;
+impl typemap::Key for IsPullRequestReviewComment { type Value = PullRequestReviewCommentEvent; }
 
-  struct IsPullRequestReviewComment;
-  impl typemap::Key for IsPullRequestReviewComment { type Value = PullRequestReviewCommentEvent; }
+struct IsPullRequest;
+impl typemap::Key for IsPullRequest { type Value = PullRequestEvent; }
 
-  struct IsPullRequest;
-  impl typemap::Key for IsPullRequest { type Value = PullRequestEvent; }
-
-  struct IsPush;
-  impl typemap::Key for IsPush { type Value = PushEvent; }
+struct IsPush;
+impl typemap::Key for IsPush { type Value = PushEvent; }
 
 
-  impl BeforeMiddleware for Deserialize {
-    fn before(&self, req: &mut Request) -> IronResult<()> {
-      let mut payload = String::new();
-      req.body.read_to_string(&mut payload).unwrap();
+impl BeforeMiddleware for Deserialize {
+  fn before(&self, req: &mut Request) -> IronResult<()> {
+    let mut payload = String::new();
+    req.body.read_to_string(&mut payload).unwrap();
 
-      let headers = req.headers.clone();
-      let event_header = headers.get::<GithubEventHeader>();
-      event_header.map(|header| {
-        match header.event_name.as_ref() {
-          "issue_comment" => {
-            req.extensions.insert::<EventInfo>(EventType::IssueComment);
-            req.extensions.insert::<IsIssueComment>(json::decode(&payload).unwrap());
-          },
-          "pull_request_review_comment" => {
-            req.extensions.insert::<EventInfo>(EventType::PullRequestReviewComment);
-            req.extensions.insert::<IsPullRequestReviewComment>(json::decode(&payload).unwrap());
-          },
-          "pull_request" => {
-            req.extensions.insert::<EventInfo>(EventType::PullRequest);
-            req.extensions.insert::<IsPullRequest>(json::decode(&payload).unwrap());
-          },
-          "push" => {
-            req.extensions.insert::<EventInfo>(EventType::Push);
-            req.extensions.insert::<IsPush>(json::decode(&payload).unwrap());
-          },
-          _ => {req.extensions.insert::<EventInfo>(EventType::UnknownEvent);}
-        }
-      });
-      Ok(())
-    }
-  }
-
-
-  fn handle_webhooks(req: &mut Request) -> IronResult<Response> {
-    let possible_event_type = req.extensions.get::<EventInfo>();
-
-    match possible_event_type {
-      Some(&EventType::IssueComment) => Ok(Response::with((status::Accepted, "{\"body\":\"Successful recv of issue comment\"}"))),
-      Some(&EventType::PullRequestReviewComment) => Ok(Response::with((status::Accepted, "{\"body\":\"Successful recv of pull request review comment\"}"))),
-      Some(&EventType::PullRequest) => Ok(Response::with((status::Accepted, "{\"body\":\"Successful recv of pull request\"}"))),
-      Some(&EventType::Push) => Ok(Response::with((status::Accepted, "{\"body\":\"Successful recv of push\"}"))),
-      Some(&EventType::UnknownEvent) => Ok(Response::with((status::Accepted, "{\"body\":\"Recv an unhandled event\"}"))),
-      None => Ok(Response::with((status::Accepted, "{\"body\":\"No event header provided\"}")))
-    }
-  }
-
-  struct DeliverActionables {
-    issue_comment_tx: Mutex<Sender<IssueCommentEvent>>,
-    pull_request_review_tx: Mutex<Sender<PullRequestReviewCommentEvent>>,
-    pull_request_tx: Mutex<Sender<PullRequestEvent>>,
-  }
-
-  impl AfterMiddleware for DeliverActionables {
-    fn after(&self, req: &mut Request, response: Response) -> IronResult<Response> {
-      let possible_event_type = req.extensions.remove::<EventInfo>();
-      match possible_event_type {
-        Some(EventType::IssueComment) => {
-          let possible_payload = req.extensions.remove::<IsIssueComment>();
-          possible_payload.map(|payload: IssueCommentEvent| self.issue_comment_tx.lock().map(|sender| sender.send(payload)));
-
+    let headers = req.headers.clone();
+    let event_header = headers.get::<GithubEventHeader>();
+    event_header.map(|header| {
+      match header.event_name.as_ref() {
+        "issue_comment" => {
+          req.extensions.insert::<EventInfo>(EventType::IssueComment);
+          req.extensions.insert::<IsIssueComment>(json::decode(&payload).unwrap());
         },
-        Some(EventType::PullRequestReviewComment) => {
-          let possible_payload = req.extensions.remove::<IsPullRequestReviewComment>();
-          possible_payload.map(|payload: PullRequestReviewCommentEvent| self.pull_request_review_tx.lock().map(|sender| sender.send(payload)));
+        "pull_request_review_comment" => {
+          req.extensions.insert::<EventInfo>(EventType::PullRequestReviewComment);
+          req.extensions.insert::<IsPullRequestReviewComment>(json::decode(&payload).unwrap());
         },
-        Some(EventType::PullRequest) => {
-          let possible_payload = req.extensions.remove::<IsPullRequest>();
-          possible_payload.map(|payload: PullRequestEvent| self.pull_request_tx.lock().map(|sender| sender.send(payload)));
+        "pull_request" => {
+          req.extensions.insert::<EventInfo>(EventType::PullRequest);
+          req.extensions.insert::<IsPullRequest>(json::decode(&payload).unwrap());
         },
-        _ => ()
+        "push" => {
+          req.extensions.insert::<EventInfo>(EventType::Push);
+          req.extensions.insert::<IsPush>(json::decode(&payload).unwrap());
+        },
+        _ => {req.extensions.insert::<EventInfo>(EventType::UnknownEvent);}
       }
-      Ok(response)
+    });
+    Ok(())
+  }
+}
+
+
+fn handle_webhooks(req: &mut Request) -> IronResult<Response> {
+  let possible_event_type = req.extensions.get::<EventInfo>();
+
+  match possible_event_type {
+    Some(&EventType::IssueComment) => Ok(Response::with((status::Accepted, "{\"body\":\"Successful recv of issue comment\"}"))),
+    Some(&EventType::PullRequestReviewComment) => Ok(Response::with((status::Accepted, "{\"body\":\"Successful recv of pull request review comment\"}"))),
+    Some(&EventType::PullRequest) => Ok(Response::with((status::Accepted, "{\"body\":\"Successful recv of pull request\"}"))),
+    Some(&EventType::Push) => Ok(Response::with((status::Accepted, "{\"body\":\"Successful recv of push\"}"))),
+    Some(&EventType::UnknownEvent) => Ok(Response::with((status::Accepted, "{\"body\":\"Recv an unhandled event\"}"))),
+    None => Ok(Response::with((status::Accepted, "{\"body\":\"No event header provided\"}")))
+  }
+}
+
+struct DeliverActionables {
+  issue_comment_tx: Mutex<Sender<IssueCommentEvent>>,
+  pull_request_review_tx: Mutex<Sender<PullRequestReviewCommentEvent>>,
+  pull_request_tx: Mutex<Sender<PullRequestEvent>>,
+}
+
+impl AfterMiddleware for DeliverActionables {
+  fn after(&self, req: &mut Request, response: Response) -> IronResult<Response> {
+    let possible_event_type = req.extensions.remove::<EventInfo>();
+    match possible_event_type {
+      Some(EventType::IssueComment) => {
+        let possible_payload = req.extensions.remove::<IsIssueComment>();
+        possible_payload.map(|payload: IssueCommentEvent| self.issue_comment_tx.lock().map(|sender| sender.send(payload)));
+
+      },
+      Some(EventType::PullRequestReviewComment) => {
+        let possible_payload = req.extensions.remove::<IsPullRequestReviewComment>();
+        possible_payload.map(|payload: PullRequestReviewCommentEvent| self.pull_request_review_tx.lock().map(|sender| sender.send(payload)));
+      },
+      Some(EventType::PullRequest) => {
+        let possible_payload = req.extensions.remove::<IsPullRequest>();
+        possible_payload.map(|payload: PullRequestEvent| self.pull_request_tx.lock().map(|sender| sender.send(payload)));
+      },
+      _ => ()
     }
+    Ok(response)
   }
+}
 
-  pub fn spawn_listener(
-    issue_comment_tx: Sender<IssueCommentEvent>,
-    pull_request_tx: Sender<PullRequestEvent>,
-    pull_request_review_tx: Sender<PullRequestReviewCommentEvent>
-    ) -> Iron<Router> {
+pub fn spawn_listener(
+  issue_comment_tx: Sender<IssueCommentEvent>,
+  pull_request_tx: Sender<PullRequestEvent>,
+  pull_request_review_tx: Sender<PullRequestReviewCommentEvent>
+  ) -> Iron<Router> {
 
-    let deliverer = DeliverActionables {
-      issue_comment_tx: Mutex::new(issue_comment_tx),
-      pull_request_tx: Mutex::new(pull_request_tx),
-      pull_request_review_tx: Mutex::new(pull_request_review_tx),
-    };
-    let mut webhook_chain = Chain::new(handle_webhooks);
-    webhook_chain.link_before(Deserialize);
-    webhook_chain.link_after(deliverer);
+  let deliverer = DeliverActionables {
+    issue_comment_tx: Mutex::new(issue_comment_tx),
+    pull_request_tx: Mutex::new(pull_request_tx),
+    pull_request_review_tx: Mutex::new(pull_request_review_tx),
+  };
+  let mut webhook_chain = Chain::new(handle_webhooks);
+  webhook_chain.link_before(Deserialize);
+  webhook_chain.link_after(deliverer);
 
-    let mut router = Router::new();
-    router.get("/", handle_root);
-    router.post("/github_webhooks", webhook_chain);
+  let mut router = Router::new();
+  router.get("/", handle_root);
+  router.post("/github_webhooks", webhook_chain);
 
-    Iron::new(router)
-  }
+  Iron::new(router)
 }

--- a/src/listening.rs
+++ b/src/listening.rs
@@ -15,12 +15,12 @@ mod listening {
   use std::ascii::AsciiExt;
   use std::sync::Mutex;
 
-  use github_v3::event_types::{
+  use github_v3::types::comments::{
     IssueCommentEvent,
-    PullRequestEvent,
     PullRequestReviewCommentEvent,
-    PushEvent,
   };
+  use github_v3::types::pull_requests::PullRequestEvent;
+  use github_v3::types::PushEvent;
 
   use rustc_serialize::{json};
   use std::sync::mpsc::Sender;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate iron;
 extern crate time;
 extern crate router;
 extern crate rustc_serialize;
+extern crate itertools;
 
 mod listening;
 mod sending;

--- a/src/sending.rs
+++ b/src/sending.rs
@@ -4,27 +4,24 @@ pub use self::sending::{
 
 mod sending {
 
-  use github_v3::{GithubClient, IssueCommenter};
-
-  use github_v3::event_types::{
-    IssueCommentEvent,
+  use github_v3::IssueCommenter;
+  use github_v3::Authorization;
+  use github_v3::github_client::GithubClient;
+  use github_v3::types::repos::Repository;
+  use github_v3::types::pull_requests::{
     PullRequestEvent,
+  };
+  use github_v3::types::comments::{
+    IssueCommentEvent,
+    CreateIssueComment,
     PullRequestReviewCommentEvent,
   };
 
-  use std::sync::mpsc::{Receiver, TryRecvError};
-
-  use github_v3::Authorization;
-  use github_v3::types::Repository;
-  use github_v3::issue_comment_types::CreateComment;
-
-  use std::thread;
-
   use std::env;
-
+  use std::thread;
   use std::thread::JoinHandle;
-
   use std::collections::HashMap;
+  use std::sync::mpsc::{Receiver, TryRecvError};
 
   use itertools::Itertools;
 
@@ -68,7 +65,7 @@ mod sending {
               let name = issue_comment.repository.name.clone();
               let owner = issue_comment.repository.owner.login.clone();
               let repo = Repository{ owner: owner, repo_name: name };
-              let response = CreateComment { body: "PTBOT: Assigning @acmcarther to this PR".to_owned() };
+              let response = CreateIssueComment { body: "PTBOT: Assigning @acmcarther to this PR".to_owned() };
               println!("LOG: Received a request for reviewers on issue {}, assigning @acmcarther", issue_id);
               let _ = client.create_comment(repo, issue_id, response);
             }

--- a/src/sending.rs
+++ b/src/sending.rs
@@ -1,84 +1,76 @@
-pub use self::sending::{
-  spawn_sender
+use github_v3::IssueCommenter;
+use github_v3::Authorization;
+use github_v3::github_client::GithubClient;
+use github_v3::types::repos::Repository;
+use github_v3::types::pull_requests::{
+  PullRequestEvent,
+};
+use github_v3::types::comments::{
+  IssueCommentEvent,
+  CreateIssueComment,
+  PullRequestReviewCommentEvent,
 };
 
-mod sending {
+use std::env;
+use std::thread;
+use std::thread::JoinHandle;
+use std::collections::HashMap;
+use std::sync::mpsc::{Receiver, TryRecvError};
 
-  use github_v3::IssueCommenter;
-  use github_v3::Authorization;
-  use github_v3::github_client::GithubClient;
-  use github_v3::types::repos::Repository;
-  use github_v3::types::pull_requests::{
-    PullRequestEvent,
-  };
-  use github_v3::types::comments::{
-    IssueCommentEvent,
-    CreateIssueComment,
-    PullRequestReviewCommentEvent,
-  };
+use itertools::Itertools;
 
-  use std::env;
-  use std::thread;
-  use std::thread::JoinHandle;
-  use std::collections::HashMap;
-  use std::sync::mpsc::{Receiver, TryRecvError};
+type RepoFullName = String;
+type RepoStatistics = ();
 
-  use itertools::Itertools;
+fn contains_monitored_repo(event: &IssueCommentEvent, monitored_repos: &HashMap<RepoFullName, RepoStatistics>) -> bool {
+  monitored_repos.contains_key(&event.repository.full_name)
+}
 
-  type RepoFullName = String;
-  type RepoStatistics = ();
+pub fn spawn_sender(
+  issue_comment_rx: Receiver<IssueCommentEvent>,
+  pull_request_rx: Receiver<PullRequestEvent>,
+  pull_request_review_rx: Receiver<PullRequestReviewCommentEvent>
+  ) -> JoinHandle<()> {
 
-  fn contains_monitored_repo(event: &IssueCommentEvent, monitored_repos: &HashMap<RepoFullName, RepoStatistics>) -> bool {
-    monitored_repos.contains_key(&event.repository.full_name)
-  }
+  let token = env::var("CATALYST_GITHUB_OAUTH_TOKEN").unwrap();
+  let repo_owner = env::var("CATALYST_REPO_OWNER").unwrap();
+  let repo_name = env::var("CATALYST_REPO_NAME").unwrap();
 
-  pub fn spawn_sender(
-    issue_comment_rx: Receiver<IssueCommentEvent>,
-    pull_request_rx: Receiver<PullRequestEvent>,
-    pull_request_review_rx: Receiver<PullRequestReviewCommentEvent>
-    ) -> JoinHandle<()> {
+  let mut monitored_repos = HashMap::new();
+  monitored_repos.insert(repo_owner.clone() + "/" + &repo_name, ());
 
-    let token = env::var("CATALYST_GITHUB_OAUTH_TOKEN").unwrap();
-    let repo_owner = env::var("CATALYST_REPO_OWNER").unwrap();
-    let repo_name = env::var("CATALYST_REPO_NAME").unwrap();
+  let client = GithubClient::new(Some(Authorization("token ".to_owned() + &token)));
 
-    let mut monitored_repos = HashMap::new();
-    monitored_repos.insert(repo_owner.clone() + "/" + &repo_name, ());
+  thread::spawn (move || {
+    let mut channels_up = true;
+    while channels_up {
+      let possible_issue_comment = issue_comment_rx.try_recv();
+      let possible_pull_request = pull_request_rx.try_recv();
+      let possible_pull_request_review = pull_request_review_rx.try_recv();
 
-    let client = GithubClient::new(Some(Authorization("token ".to_owned() + &token)));
+      let _ = possible_issue_comment
+        .map_err(|err| if err == TryRecvError::Disconnected {channels_up = false})
+        .ok()
+        .iter()
+        .filter(|issue_comment| contains_monitored_repo(issue_comment, &monitored_repos))
+        .foreach(|issue_comment| {
+          if issue_comment.comment.body.clone().contains("pt r?") {
+            let issue_id = issue_comment.issue.number.clone();
+            let name = issue_comment.repository.name.clone();
+            let owner = issue_comment.repository.owner.login.clone();
+            let repo = Repository{ owner: owner, repo_name: name };
+            let response = CreateIssueComment { body: "PTBOT: Assigning @acmcarther to this PR".to_owned() };
+            println!("LOG: Received a request for reviewers on issue {}, assigning @acmcarther", issue_id);
+            let _ = client.create_comment(repo, issue_id, response);
+          }
+        });
+      let _ = possible_pull_request.map_err(|err| if err == TryRecvError::Disconnected {channels_up = false});
+      let _ = possible_pull_request_review.map_err(|err| if err == TryRecvError::Disconnected {channels_up = false});
 
-    thread::spawn (move || {
-      let mut channels_up = true;
-      while channels_up {
-        let possible_issue_comment = issue_comment_rx.try_recv();
-        let possible_pull_request = pull_request_rx.try_recv();
-        let possible_pull_request_review = pull_request_review_rx.try_recv();
+      //possible_pull_request.map(|err| if err == TryRecvError::Disconnected {channels_up = false});
+      //possible_pull_request_review.map(|err| if err == TryRecvError::Disconnected {channels_up = false});
 
-        let _ = possible_issue_comment
-          .map_err(|err| if err == TryRecvError::Disconnected {channels_up = false})
-          .ok()
-          .iter()
-          .filter(|issue_comment| contains_monitored_repo(issue_comment, &monitored_repos))
-          .foreach(|issue_comment| {
-            if issue_comment.comment.body.clone().contains("pt r?") {
-              let issue_id = issue_comment.issue.number.clone();
-              let name = issue_comment.repository.name.clone();
-              let owner = issue_comment.repository.owner.login.clone();
-              let repo = Repository{ owner: owner, repo_name: name };
-              let response = CreateIssueComment { body: "PTBOT: Assigning @acmcarther to this PR".to_owned() };
-              println!("LOG: Received a request for reviewers on issue {}, assigning @acmcarther", issue_id);
-              let _ = client.create_comment(repo, issue_id, response);
-            }
-          });
-        let _ = possible_pull_request.map_err(|err| if err == TryRecvError::Disconnected {channels_up = false});
-        let _ = possible_pull_request_review.map_err(|err| if err == TryRecvError::Disconnected {channels_up = false});
-
-        //possible_pull_request.map(|err| if err == TryRecvError::Disconnected {channels_up = false});
-        //possible_pull_request_review.map(|err| if err == TryRecvError::Disconnected {channels_up = false});
-
-        thread::sleep_ms(2000);
-      }
-    })
-  }
-
+      thread::sleep_ms(2000);
+    }
+  })
 }

--- a/src/sending.rs
+++ b/src/sending.rs
@@ -24,6 +24,17 @@ mod sending {
 
   use std::thread::JoinHandle;
 
+  use std::collections::HashMap;
+
+  use itertools::Itertools;
+
+  type RepoFullName = String;
+  type RepoStatistics = ();
+
+  fn contains_monitored_repo(event: &IssueCommentEvent, monitored_repos: &HashMap<RepoFullName, RepoStatistics>) -> bool {
+    monitored_repos.contains_key(&event.repository.full_name)
+  }
+
   pub fn spawn_sender(
     issue_comment_rx: Receiver<IssueCommentEvent>,
     pull_request_rx: Receiver<PullRequestEvent>,
@@ -34,25 +45,34 @@ mod sending {
     let repo_owner = env::var("CATALYST_REPO_OWNER").unwrap();
     let repo_name = env::var("CATALYST_REPO_NAME").unwrap();
 
+    let mut monitored_repos = HashMap::new();
+    monitored_repos.insert(repo_owner.clone() + "/" + &repo_name, ());
+
+    let client = GithubClient::new(Some(Authorization("token ".to_owned() + &token)));
+
     thread::spawn (move || {
       let mut channels_up = true;
-      let client = GithubClient::new(Some(Authorization("token ".to_owned() + &token)));
       while channels_up {
         let possible_issue_comment = issue_comment_rx.try_recv();
         let possible_pull_request = pull_request_rx.try_recv();
         let possible_pull_request_review = pull_request_review_rx.try_recv();
 
         let _ = possible_issue_comment
-          .map(|issue_comment| {
+          .map_err(|err| if err == TryRecvError::Disconnected {channels_up = false})
+          .ok()
+          .iter()
+          .filter(|issue_comment| contains_monitored_repo(issue_comment, &monitored_repos))
+          .foreach(|issue_comment| {
             if issue_comment.comment.body.clone().contains("pt r?") {
               let issue_id = issue_comment.issue.number.clone();
-              let repo = Repository{ owner: repo_owner.clone(), repo_name: repo_name.clone() };
+              let name = issue_comment.repository.name.clone();
+              let owner = issue_comment.repository.owner.login.clone();
+              let repo = Repository{ owner: owner, repo_name: name };
               let response = CreateComment { body: "PTBOT: Assigning @acmcarther to this PR".to_owned() };
               println!("LOG: Received a request for reviewers on issue {}, assigning @acmcarther", issue_id);
               let _ = client.create_comment(repo, issue_id, response);
             }
-          })
-          .map_err(|err| if err == TryRecvError::Disconnected {channels_up = false});
+          });
         let _ = possible_pull_request.map_err(|err| if err == TryRecvError::Disconnected {channels_up = false});
         let _ = possible_pull_request_review.map_err(|err| if err == TryRecvError::Disconnected {channels_up = false});
 


### PR DESCRIPTION
This makes catalyst actually post its issue comments to the correct repo (instead of the configured repo). It limits responding to webhooks for issue comments to the configured repo.
